### PR TITLE
Update names of junit files generated and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ $ make deploy_gpu_operator CHANNEL=v1.10
 # run E2E test. deploy GPU operator from certified-operators and test operation
 $ make e2e_gpu_test
 # scale gpu machine set
-$ make scale_aws_gpu_nodes [REPLICAS=1 INSTANCE_TYPE=g4dn.xlarge
+$ make scale_aws_gpu_nodes [REPLICAS=1 INSTANCE_TYPE=g4dn.xlarge]
 ```

--- a/hack/run_test.sh
+++ b/hack/run_test.sh
@@ -134,7 +134,7 @@ function ginko_args() {
     ART_DIR="$1"
     shift
     NAME="$1"
-    echo "--output-dir=$ART_DIR --junit-report=${NAME}_report.xml --fail-fast --succinct --focus $NAME"
+    echo "--output-dir=$ART_DIR --junit-report=junit_report_${NAME}.xml --fail-fast --succinct --focus $NAME"
 }
 
 ### Init output folder


### PR DESCRIPTION
This PR is mainly to test CI integration. 
But it still contains some changes:
 - junit files now have a prefix of `junit_report_`
 - minor README change.