### PR TITLE
Fix defaultChannel when deploying from operatorhub, and deploy master bundle

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -4,8 +4,18 @@ USER root
 
 WORKDIR /test
 
+# Install dependencies: `operator-sdk`
+ARG OPERATOR_SDK_VERSION=v1.26.0
+ARG OPERATOR_SDK_URL=https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}
+RUN cd /usr/local/bin \
+    && curl -LO ${OPERATOR_SDK_URL}/operator-sdk_linux_amd64 \
+    && mv operator-sdk_linux_amd64 operator-sdk \
+    && chmod +x operator-sdk
+
+# Install dependencies: `golangci-lint & ginkgo`
 RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2 
 RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.5.1
+
 RUN mkdir /test-run-results && chmod 777 /test-run-results
 
 ENV ARTIFACT_DIR=/test-run-results

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ deploy_nfd_operator:
 	@./hack/run_test.sh deploy_nfd_operator
 
 .PHONY: deploy_gpu_operator
-deploy_gpu_operator:
+deploy_gpu_operator: deploy_nfd_operator
 	@./hack/run_test.sh deploy_gpu_operator $(CHANNEL)
 
 .PHONY: clean_artifact_dir
@@ -38,7 +38,18 @@ test_gpu_operator_metrics:
 	@./hack/run_test.sh test_gpu_operator_metrics
 
 .PHONY: e2e_gpu_test
-e2e_gpu_test: deploy_gpu_operator wait_for_gpu_operator run_gpu_workload test_gpu_operator_metrics
+e2e_gpu_test: deploy_gpu_operator gpu_full_test
+
+.PHONY: master_e2e_gpu_test
+master_e2e_gpu_test: deploy_gpu_operator_master gpu_full_test
+
+.PHONY: deploy_gpu_operator_master
+deploy_gpu_operator_master: deploy_nfd_operator
+	@./hack/run_test.sh deploy_gpu_operator_master
+
+.PHONY: gpu_full_test
+gpu_full_test: wait_for_gpu_operator run_gpu_workload test_gpu_operator_metrics
+
 
 .PHONY: scale_aws_gpu_nodes
 scale_aws_gpu_nodes:

--- a/hack/run_test.sh
+++ b/hack/run_test.sh
@@ -52,7 +52,7 @@ function deploy_gpu_operator_master() {
     print_test_title "${FUNCNAME[0]}"
     ART_DIR=$(dirgen "${FUNCNAME[0]}")
     export DEPLOYED_FROM_MASTER=true
-	operator-sdk run bundle --timeout=10m -n "gpu-operator-test" \
+    operator-sdk run bundle --timeout=10m -n "gpu-operator-test" \
         --install-mode OwnNamespace \
         ${GPU_OPERATOR_MASTER_BUNDLE} || error_and_exit "${FUNCNAME[0]} Test Failed" 5
     deploy_gpu_operator "" || error_and_exit "${FUNCNAME[0]} Test Failed" 6

--- a/ocputils/operator.go
+++ b/ocputils/operator.go
@@ -19,7 +19,7 @@ func GetCatalogSource(config *rest.Config, namespace string, name string) (*oper
 	if err != nil {
 		return nil, err
 	}
-	return opClient.CatalogSources("openshift-marketplace").Get(context.TODO(), name, metav1.GetOptions{})
+	return opClient.CatalogSources(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }
 
 func GetPackageManifest(config *rest.Config, namespace string, name string) (*pkgmanifestv1.PackageManifest, error) {
@@ -27,8 +27,7 @@ func GetPackageManifest(config *rest.Config, namespace string, name string) (*pk
 	if err != nil {
 		return nil, err
 	}
-	return pClient.PackageManifests("openshift-marketplace").Get(context.TODO(), name, metav1.GetOptions{})
-
+	return pClient.PackageManifests(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }
 
 func GetOperatorGroup(config *rest.Config, namespace string, name string) (*operatorsv1.OperatorGroup, error) {

--- a/setup/deploy_gpu_op_test.go
+++ b/setup/deploy_gpu_op_test.go
@@ -2,7 +2,9 @@ package setup
 
 import (
 	"encoding/json"
-	"fmt"
+	"strings"
+	"time"
+
 	"k8s.io/apimachinery/pkg/runtime"
 
 	gpuv1 "github.com/NVIDIA/gpu-operator/api/v1"
@@ -20,7 +22,7 @@ import (
 )
 
 const (
-	deployMasterEnvVar = "DEPLOY_GPU_OP_NVIDIA_MAIN"
+	deployedFromMaster = "DEPLOYED_FROM_MASTER"
 )
 
 var _ = Describe("deploy_gpu_operator :", Ordered, func() {
@@ -46,7 +48,7 @@ var _ = Describe("deploy_gpu_operator :", Ordered, func() {
 	})
 	Context("from certified operators", Ordered, func() {
 		BeforeAll(func() {
-			if testutils.SkipTestIfEnvVarSet(deployMasterEnvVar, true) {
+			if testutils.SkipTestIfEnvVarSet(deployedFromMaster, true) {
 				return
 			}
 		})
@@ -90,16 +92,50 @@ var _ = Describe("deploy_gpu_operator :", Ordered, func() {
 			err = testutils.SaveAsJsonToArtifactsDir(sub, "gpu_operator_subscription.json")
 			Expect(err).ToNot(HaveOccurred())
 		})
+	})
 
+	Context("post install setup", Ordered, func() {
+		var (
+			namespace string
+		)
+
+		It("get csv", func() {
+			err := testutils.ExecWithRetryBackoff("get gpu op csv", func() bool {
+				csvs, err := ocputils.GetCsvsByLabel(config, "", "")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(csvs.Items).ToNot(BeEmpty())
+				for _, csv := range csvs.Items {
+					if strings.Contains(csv.Name, "gpu-operator-certified") {
+						clusterServiceVersion = &csv
+						namespace = csv.Namespace
+						return true
+					}
+				}
+				return false
+			}, 30, 30*time.Second)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(clusterServiceVersion).ToNot(BeNil(), "CSV not found")
+			Expect(namespace).ToNot(BeEmpty())
+		})
 		It("wait Until CSV is installed", func() {
-			labelSelector := fmt.Sprintf("operators.coreos.com/%v.%v", operatorPkgName, internal.Config.NameSpace)
-			csv, err := waitForCsvPhase(config, internal.Config.NameSpace, labelSelector, "Succeeded")
+			succeeded := operatorsv1alpha1.ClusterServiceVersionPhase("Succeeded")
+			testutils.Printf("Info", "GPU Operator name=%v namespace=%v version=%v", clusterServiceVersion.Name, clusterServiceVersion.Namespace, clusterServiceVersion.Spec.Version.String())
+			if clusterServiceVersion.Status.Phase != succeeded {
+				err := testutils.ExecWithRetryBackoff("Wait for CSV to be Succeeded", func() bool {
+					csv, err := ocputils.GetCsvByName(config, clusterServiceVersion.Namespace, clusterServiceVersion.Name)
+					if err != nil {
+						return false
+					}
+					clusterServiceVersion = csv
+					return clusterServiceVersion.Status.Phase == succeeded
+				}, 15, 30*time.Second)
+				Expect(err).ToNot(HaveOccurred())
+			}
+			Expect(clusterServiceVersion.Status.Phase).To(Equal(succeeded), "CSV Phase is not Succeeded")
+			err := testutils.SaveAsJsonToArtifactsDir(clusterServiceVersion, "gpu_operator_csv.json")
 			Expect(err).ToNot(HaveOccurred())
-			err = testutils.SaveAsJsonToArtifactsDir(csv, "gpu_operator_csv.json")
+			err = testutils.SaveToArtifactsDir([]byte(clusterServiceVersion.Spec.Version.String()), "gpu_operator_version.txt")
 			Expect(err).ToNot(HaveOccurred())
-			err = testutils.SaveToArtifactsDir([]byte(csv.Spec.Version.String()), "gpu_operator_version.txt")
-			Expect(err).ToNot(HaveOccurred())
-			clusterServiceVersion = &csv
 		})
 
 		It("deploy GPU ClusterPolicy", func() {
@@ -110,7 +146,7 @@ var _ = Describe("deploy_gpu_operator :", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cpJson.Items).ToNot(BeEmpty())
 			unstructObj := cpJson.Items[0]
-			unstructObj.SetNamespace(internal.Config.NameSpace)
+			unstructObj.SetNamespace(namespace)
 
 			resp, err := ocputils.CreateDynamicResource(config, gpuv1.GroupVersion.WithResource("clusterpolicies"), &unstructObj, "")
 
@@ -121,17 +157,7 @@ var _ = Describe("deploy_gpu_operator :", Ordered, func() {
 			err = testutils.SaveAsJsonToArtifactsDir(respCp, "gpu_cr_cluster_policy.json")
 			Expect(err).ToNot(HaveOccurred())
 		})
-	})
 
-	Context("NVIDIA's Main branch Bundle", Ordered, func() {
-		BeforeAll(func() {
-			if testutils.SkipTestIfEnvVarSet(deployMasterEnvVar, false) {
-				return
-			}
-		})
-		It("deploy Prebuilt nvidia bundle.", func() {
-
-		})
 	})
 
 })

--- a/setup/deploy_gpu_op_test.go
+++ b/setup/deploy_gpu_op_test.go
@@ -64,10 +64,10 @@ var _ = Describe("deploy_gpu_operator :", Ordered, func() {
 			var err error
 			pkg, err = ocputils.GetPackageManifest(config, catalogSourceNS, operatorPkgName)
 			Expect(err).ToNot(HaveOccurred())
-			testutils.Printf("PKG Manifest", "GPU Operator PackageManifest current version [%v]: %v", pkg.Status.Channels[0].Name, pkg.Status.Channels[0].CurrentCSV)
+			testutils.Printf("PKG Manifest", "GPU Operator PackageManifest default channel '%v'", pkg.Status.DefaultChannel)
 			if len(gpuOpChannel) == 0 {
-				// No channel specified - use latest
-				gpuOpChannel = pkg.Status.Channels[0].Name
+				// No channel specified - use defaultChannel
+				gpuOpChannel = pkg.Status.DefaultChannel
 			}
 			err = testutils.SaveAsJsonToArtifactsDir(pkg, "gpu_operator_packagemanifest.json")
 			Expect(err).ToNot(HaveOccurred())

--- a/setup/deploy_nfd_test.go
+++ b/setup/deploy_nfd_test.go
@@ -37,6 +37,7 @@ var _ = Describe("deploy_nfd_operator :", Ordered, func() {
 		nfdCatalogSource = "unset"
 		nfdCatalogSourceNS = "unset"
 		nfdCsvLabelSelector = "unset"
+		nfdPkgNS = "openshift-marketplace"
 
 		var err error
 		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)

--- a/tests/wait_for_gpu_operator_test.go
+++ b/tests/wait_for_gpu_operator_test.go
@@ -42,10 +42,12 @@ var _ = Describe("wait_for_gpu_operator :", Ordered, func() {
 			if strings.Contains(csv.Name, "gpu-operator-certified") {
 				gpuOperatorCsv = &csv
 				namespace = csv.Namespace
+				break
 			}
 		}
 		Expect(gpuOperatorCsv).ToNot(BeNil(), "CSV not found")
 		Expect(namespace).ToNot(BeEmpty())
+		testutils.Printf("Info", "GPU Operator name=%v namespace=%v version=%v", gpuOperatorCsv.Name, gpuOperatorCsv.Namespace, gpuOperatorCsv.Spec.Version.String())
 		if gpuOperatorCsv.Status.Phase != succeeded {
 			err = testutils.ExecWithRetryBackoff("Wait for CSV to be Succeeded", func() bool {
 				csv, err := ocputils.GetCsvByName(config, gpuOperatorCsv.Namespace, gpuOperatorCsv.Name)
@@ -58,10 +60,9 @@ var _ = Describe("wait_for_gpu_operator :", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 		}
 		Expect(gpuOperatorCsv.Status.Phase).To(Equal(succeeded), "CSV Phase is not Succeeded")
-		testutils.Printf("Info", "GPU Operator namespace = %v", namespace)
-		csvJson, err := json.MarshalIndent(gpuOperatorCsv, "", " ")
+		err = testutils.SaveAsJsonToArtifactsDir(gpuOperatorCsv, "gpu_operator_csv.json")
 		Expect(err).ToNot(HaveOccurred())
-		err = testutils.SaveToArtifactsDir(csvJson, "gpu_operator_csv.json")
+		err = testutils.SaveToArtifactsDir([]byte(gpuOperatorCsv.Spec.Version.String()), "gpu_operator_version.txt")
 		Expect(err).ToNot(HaveOccurred())
 	})
 


### PR DESCRIPTION
This PR adds: 
 - the ability to test NVIDIA's [prebuilt master bundle](https://gitlab.com/nvidia/kubernetes/gpu-operator/container_registry/3429980).
   - The bundle will be deployed/installed via the OperatorSDK CLI (v1.26.0).

 - In addition, the PR contains a **fix** for `deploy_gpu_operator` target. 
   - when `CHANNEL` is not specified, create a subscription to `defaultChannel`.