### PR TITLE
ensure namespace has the openshift.io/cluster-monitoring label 

### DIFF
--- a/hack/run_test.sh
+++ b/hack/run_test.sh
@@ -142,7 +142,7 @@ function ginko_args() {
     ART_DIR="$1"
     shift
     NAME="$1"
-    echo "--output-dir=$ART_DIR --junit-report=junit_report_${NAME}.xml --fail-fast --succinct --focus $NAME"
+    echo "--output-dir=$ART_DIR --junit-report=junit_report_${NAME}.xml --fail-fast --succinct --no-color --focus $NAME"
 }
 
 ### Init output folder

--- a/ocputils/namespace.go
+++ b/ocputils/namespace.go
@@ -5,6 +5,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -35,4 +36,11 @@ func GetNamespace(config *rest.Config, name string) (*corev1.Namespace, error) {
 		return nil, err
 	}
 	return clientset.CoreV1().Namespaces().Get(context.TODO(), name, metav1.GetOptions{})
+}
+func PatchNamespace(config *rest.Config, name string, data []byte, pt types.PatchType) (*corev1.Namespace, error) {
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return clientset.CoreV1().Namespaces().Patch(context.TODO(), name, pt, data, metav1.PatchOptions{})
 }

--- a/ocputils/node.go
+++ b/ocputils/node.go
@@ -65,12 +65,12 @@ func GetWorkerMachineSets(config *rest.Config, namespace string) (*machinev1beta
 	return list, nil
 }
 
-func PatchMachineSet(config *rest.Config, ms *machinev1beta1.MachineSet, data []byte) (*machinev1beta1.MachineSet, error) {
+func PatchMachineSet(config *rest.Config, ms *machinev1beta1.MachineSet, data []byte, pt types.PatchType) (*machinev1beta1.MachineSet, error) {
 	clientset, err := machinev1beta1client.NewForConfig(config)
 	if err != nil {
 		return nil, err
 	}
-	return clientset.MachineSets(ms.Namespace).Patch(context.TODO(), ms.Name, types.MergePatchType, data, metav1.PatchOptions{})
+	return clientset.MachineSets(ms.Namespace).Patch(context.TODO(), ms.Name, pt, data, metav1.PatchOptions{})
 }
 
 func GetMachineSet(config *rest.Config, namespace string, name string) (*machinev1beta1.MachineSet, error) {

--- a/setup/scale_aws_gpu_nodes_test.go
+++ b/setup/scale_aws_gpu_nodes_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	machinesetv1b1 "github.com/openshift/api/machine/v1beta1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -100,7 +101,7 @@ var _ = Describe("scale_aws_gpu_nodes : ", Ordered, func() {
 	It("ensure number of replicas on MachineSet", func() {
 		if gpuMachineset.Spec.Replicas != &replicas {
 			patch := fmt.Sprintf("{\"spec\": {\"replicas\": %v}}", replicas)
-			ms, err := ocputils.PatchMachineSet(config, gpuMachineset, []byte(patch))
+			ms, err := ocputils.PatchMachineSet(config, gpuMachineset, []byte(patch), types.MergePatchType)
 			Expect(err).ToNot(HaveOccurred())
 			gpuMachineset = ms
 		}

--- a/tests/run_gpu_workload_test.go
+++ b/tests/run_gpu_workload_test.go
@@ -40,7 +40,6 @@ var _ = Describe("run_gpu_workload :", Ordered, func() {
 	})
 
 	It("create gpu-burn namespace", func() {
-		By("fooo")
 		ns, err := ocputils.CreateNamespace(config, namespace)
 		Expect(err).ToNot(HaveOccurred())
 		err = testutils.SaveAsJsonToArtifactsDir(ns, "gpu_burn_namespace.json")


### PR DESCRIPTION
This PR should fix the issue with metrics tests on operator versions <= 1.9