### PR TITLE
Added fallback when creating rest client config

### DIFF
--- a/setup/deploy_gpu_op_test.go
+++ b/setup/deploy_gpu_op_test.go
@@ -13,7 +13,6 @@ import (
 	pkgmanifestv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"ci-tools-nvidia-gpu-operator/internal"
 	"ci-tools-nvidia-gpu-operator/ocputils"
@@ -25,7 +24,6 @@ const (
 )
 
 var _ = Describe("deploy_gpu_operator :", Ordered, func() {
-	kubeconfig := internal.Config.KubeconfigPath
 	var (
 		config                *rest.Config
 		pkg                   *pkgmanifestv1.PackageManifest
@@ -41,9 +39,7 @@ var _ = Describe("deploy_gpu_operator :", Ordered, func() {
 		catalogSourceNS = "openshift-marketplace"
 		operatorPkgName = "gpu-operator-certified"
 
-		var err error
-		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
-		Expect(err).ToNot(HaveOccurred())
+		config = internal.Config.ClientConfig
 	})
 
 	It("ensure namespace exists", func() {

--- a/setup/deploy_nfd_test.go
+++ b/setup/deploy_nfd_test.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"ci-tools-nvidia-gpu-operator/internal"
 	"ci-tools-nvidia-gpu-operator/ocputils"
@@ -25,7 +24,6 @@ const (
 var _ = Describe("deploy_nfd_operator :", Ordered, func() {
 	var (
 		config              *rest.Config
-		kubeconfig          string
 		nfdOpName           string
 		nfdChannel          string
 		nfdCatalogSource    string
@@ -36,7 +34,6 @@ var _ = Describe("deploy_nfd_operator :", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		kubeconfig = internal.Config.KubeconfigPath
 		nfdOpName = "nfd"
 		nfdChannel = "unset"
 		nfdCatalogSource = "unset"
@@ -44,9 +41,7 @@ var _ = Describe("deploy_nfd_operator :", Ordered, func() {
 		nfdCsvLabelSelector = "unset"
 		nfdPkgNS = "openshift-marketplace"
 
-		var err error
-		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
-		Expect(err).ToNot(HaveOccurred())
+		config = internal.GetClientConfig()
 	})
 
 	It("check NFD PackageManifest", func() {

--- a/setup/ocm_addons_test.go
+++ b/setup/ocm_addons_test.go
@@ -10,7 +10,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"ci-tools-nvidia-gpu-operator/internal"
 	"ci-tools-nvidia-gpu-operator/ocputils"
@@ -52,11 +51,8 @@ var _ = Describe("ocm_addons_setup :", Ordered, func() {
 		ocmClusterId *string
 	)
 	BeforeAll(func() {
-		kubeconfig := internal.Config.KubeconfigPath
 
-		var err error
-		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
-		Expect(err).ToNot(HaveOccurred())
+		config = internal.GetClientConfig()
 
 		osde2eSecret, err := ocputils.GetSecret(config, osde2eSecretNamespace, osde2eSecretName)
 		Expect(err).ToNot(HaveOccurred())

--- a/setup/ocp_connection_test.go
+++ b/setup/ocp_connection_test.go
@@ -2,11 +2,9 @@ package setup
 
 import (
 	"fmt"
-	"os"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"ci-tools-nvidia-gpu-operator/internal"
 	"ci-tools-nvidia-gpu-operator/ocputils"
@@ -14,18 +12,9 @@ import (
 )
 
 var _ = Describe("test_ocp_connection :", Ordered, func() {
-	kubeconfigPath := internal.Config.KubeconfigPath
+	It("should successfuly get server versions", func() {
+		config := internal.GetClientConfig()
 
-	It("should have a valid kubeconfig path", func() {
-		testutils.Printf("Info", "Using KUBECONFIG=%v", kubeconfigPath)
-		Expect(kubeconfigPath).ToNot(BeEmpty())
-		_, err := os.Stat(kubeconfigPath)
-		Expect(err).ToNot(HaveOccurred(), "Failed to fetch file info of kubeconfig")
-	})
-
-	It("Should successfuly get server versions", func() {
-		config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
-		Expect(err).ToNot(HaveOccurred())
 		serverVersion, err := ocputils.GetServerVersion(config)
 		Expect(err).ToNot(HaveOccurred())
 		ocpVersionMsg := fmt.Sprintf("K8s Version: %v\nOCP Version: %v\n", serverVersion.Kubernetes, serverVersion.Openshift)

--- a/setup/scale_aws_gpu_nodes_test.go
+++ b/setup/scale_aws_gpu_nodes_test.go
@@ -12,7 +12,6 @@ import (
 	machinesetv1b1 "github.com/openshift/api/machine/v1beta1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"ci-tools-nvidia-gpu-operator/internal"
 	"ci-tools-nvidia-gpu-operator/ocputils"
@@ -24,20 +23,17 @@ var _ = Describe("scale_aws_gpu_nodes : ", Ordered, func() {
 	var (
 		config        *rest.Config
 		gpuMachineset *machinesetv1b1.MachineSet
-		kubeconfig    string
 		instanceType  string
 		namespace     string
 		replicas      int32
 	)
 
 	BeforeAll(func() {
-		kubeconfig = internal.Config.KubeconfigPath
 		instanceType = internal.Config.CiMachineSetInstanceType
 		namespace = "openshift-machine-api"
 
-		var err error
-		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
-		Expect(err).ToNot(HaveOccurred())
+		config = internal.GetClientConfig()
+
 		r, err := strconv.ParseInt(internal.Config.CiMachineSetReplicas, 10, 32)
 		Expect(err).ToNot(HaveOccurred(), "Invalid replicas value")
 		replicas = int32(r)

--- a/tests/gpu_addon_must_gather_test.go
+++ b/tests/gpu_addon_must_gather_test.go
@@ -9,7 +9,6 @@ import (
 	. "github.com/onsi/gomega"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"ci-tools-nvidia-gpu-operator/internal"
 	"ci-tools-nvidia-gpu-operator/ocputils"
@@ -17,7 +16,6 @@ import (
 )
 
 var _ = Describe("gpu_addon_must_gather :", Ordered, func() {
-	kubeconfig := internal.Config.KubeconfigPath
 	var (
 		config          *rest.Config
 		gpuAddonCsv     *operatorsv1alpha1.ClusterServiceVersion
@@ -25,9 +23,8 @@ var _ = Describe("gpu_addon_must_gather :", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		var err error
-		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
-		Expect(err).ToNot(HaveOccurred())
+		config = internal.GetClientConfig()
+
 	})
 	It("fetch must gather image from csv", func() {
 		csvs, err := ocputils.GetCsvsByLabel(config, "", "")

--- a/tests/gpu_operator_metrics_test.go
+++ b/tests/gpu_operator_metrics_test.go
@@ -14,7 +14,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"ci-tools-nvidia-gpu-operator/internal"
 	"ci-tools-nvidia-gpu-operator/ocputils"
@@ -32,17 +31,13 @@ var _ = Describe("test_gpu_operator_metrics :", Ordered, func() {
 	var (
 		config         *rest.Config
 		gpuOperatorCsv *operatorsv1alpha1.ClusterServiceVersion = nil
-		kubeconfig     string
 		namespace      string
 		gpuOpVersion   *version.OperatorVersion
 	)
 
 	BeforeAll(func() {
-		kubeconfig = internal.Config.KubeconfigPath
+		config = internal.GetClientConfig()
 
-		var err error
-		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
-		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("capture GPU Operator namespace and version", func() {

--- a/tests/run_gpu_workload_test.go
+++ b/tests/run_gpu_workload_test.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"ci-tools-nvidia-gpu-operator/internal"
 	"ci-tools-nvidia-gpu-operator/ocputils"
@@ -22,21 +21,17 @@ import (
 var _ = Describe("run_gpu_workload :", Ordered, func() {
 	var (
 		config        *rest.Config
-		kubeconfig    string
 		namespace     string
 		gpuBurnImage  string
 		daemonsetName string
 	)
 
 	BeforeAll(func() {
-		kubeconfig = internal.Config.KubeconfigPath
 		namespace = "gpu-burn-test"
 		gpuBurnImage = "quay.io/openshift-psap/gpu-burn"
 		daemonsetName = "gpu-burn-daemonset"
 
-		var err error
-		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
-		Expect(err).ToNot(HaveOccurred())
+		config = internal.GetClientConfig()
 	})
 
 	It("create gpu-burn namespace", func() {

--- a/tests/wait_for_gpu_operator_test.go
+++ b/tests/wait_for_gpu_operator_test.go
@@ -11,7 +11,6 @@ import (
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"ci-tools-nvidia-gpu-operator/internal"
 	"ci-tools-nvidia-gpu-operator/ocputils"
@@ -19,7 +18,6 @@ import (
 )
 
 var _ = Describe("wait_for_gpu_operator :", Ordered, func() {
-	kubeconfig := internal.Config.KubeconfigPath
 	var (
 		config         *rest.Config
 		namespace      string
@@ -28,9 +26,7 @@ var _ = Describe("wait_for_gpu_operator :", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		var err error
-		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
-		Expect(err).ToNot(HaveOccurred())
+		config = internal.GetClientConfig()
 	})
 
 	It("GPU operator should be installed successfully", func() {

--- a/tests/wait_for_nfd_operator_test.go
+++ b/tests/wait_for_nfd_operator_test.go
@@ -9,7 +9,6 @@ import (
 	. "github.com/onsi/gomega"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"ci-tools-nvidia-gpu-operator/internal"
 	"ci-tools-nvidia-gpu-operator/ocputils"
@@ -17,7 +16,6 @@ import (
 )
 
 var _ = Describe("wait_for_nfd_operator :", Ordered, func() {
-	kubeconfig := internal.Config.KubeconfigPath
 	var (
 		config         *rest.Config
 		namespace      string
@@ -25,9 +23,7 @@ var _ = Describe("wait_for_nfd_operator :", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		var err error
-		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
-		Expect(err).ToNot(HaveOccurred())
+		config = internal.GetClientConfig()
 	})
 
 	It("NFD Operator Should Be Installed successfully", func() {


### PR DESCRIPTION
When creating the client config, if `KUBECONFIG` is found invalid, fallback to creating from in-cluster configuration.

Creation of the client was extracted to an internal function, and will panic when both methods of creating configs have failed. This PR should solve the current `osde2e` fails we have due to invalid `KUBECONFIG`. `osde2e` is using **in-cluster** configuration