### PR TITLE
Changed default namespace to be `nvidia-gpu-operator`

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -19,7 +19,7 @@ type config struct {
 }
 
 var Config = config{
-	NameSpace:                GetVarDefault("WORKING_NAMESPACE", "gpu-operator-test"),
+	NameSpace:                GetVarDefault("WORKING_NAMESPACE", "nvidia-gpu-operator"),
 	GpuOperatorChannel:       GetVarDefault("GPU_CHANNEL", ""),
 	KubeconfigPath:           GetVarDefault("KUBECONFIG", ".kubeconfig"),
 	ArtifactDir:              GetVarDefault("ARTIFACT_DIR", "/tmp/gpu-test"),


### PR DESCRIPTION
Otherwise, the GPU operator does not label the namespace for monitoring. ([ref](https://gitlab.com/nvidia/kubernetes/gpu-operator/-/blob/master/controllers/state_manager.go#L616))

This PR might help solve some 4.12 CI fails.