### PR TITLE
Update project Go version to 1.18 and use 1.18 tag for build images

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.18.4
+FROM registry.access.redhat.com/ubi8/go-toolset:1.18
 
 USER root
 
@@ -13,7 +13,7 @@ RUN cd /usr/local/bin \
     && chmod +x operator-sdk
 
 # Install dependencies: `golangci-lint & ginkgo`
-RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2 
+RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
 RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.5.1
 
 RUN mkdir /test-run-results && chmod 777 /test-run-results

--- a/Containerfile.osde2e
+++ b/Containerfile.osde2e
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.18.4
+FROM registry.access.redhat.com/ubi8/go-toolset:1.18
 
 USER root
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module ci-tools-nvidia-gpu-operator
 
-go 1.19
+go 1.18
 
 require (
 	github.com/NVIDIA/gpu-operator v1.8.3-0.20220930173732-1d8f71f15759


### PR DESCRIPTION
Signed-off-by: Michail Resvanis <mresvani@redhat.com>