### PR TITLE
Bump containerfile dependency versions.

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -13,8 +13,8 @@ RUN cd /usr/local/bin \
     && chmod +x operator-sdk
 
 # Install dependencies: `golangci-lint & ginkgo`
-RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
-RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.5.1
+RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
+RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.7.0
 
 RUN mkdir /test-run-results && chmod 777 /test-run-results
 

--- a/Containerfile.osde2e
+++ b/Containerfile.osde2e
@@ -16,7 +16,7 @@ ARG OCP_CLI_URL=https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp
 RUN curl -L ${OCP_CLI_URL} | tar xfz - -C /usr/local/bin oc
 
 # Install dependencies: `ginkgo`
-RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.5.1
+RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.7.0
 
 RUN mkdir /test-run-results && chmod 777 /test-run-results
 

--- a/ocputils/secret.go
+++ b/ocputils/secret.go
@@ -5,7 +5,7 @@ import (
 	"compress/gzip"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,7 +32,7 @@ func GetSecretValue(secret *corev1.Secret, data string, isGziped bool) (*string,
 		if err != nil {
 			return nil, err
 		}
-		val, err = ioutil.ReadAll(gzReader)
+		val, err = io.ReadAll(gzReader)
 		if err != nil {
 			return nil, err
 		}

--- a/testutils/common.go
+++ b/testutils/common.go
@@ -3,7 +3,6 @@ package testutils
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"time"
@@ -35,7 +34,7 @@ func ExecWithRetryBackoff(debugTag string, fn TestFunc, maxRetries int, interval
 func SaveToArtifactsDir(data []byte, filename string) error {
 	filepath := path.Join(internal.Config.ArtifactDir, filename)
 	Printf("SaveToArtifactsDir", "Writing data to file: %v", filepath)
-	return ioutil.WriteFile(filepath, data, 0644)
+	return os.WriteFile(filepath, data, 0644)
 }
 
 func SaveAsJsonToArtifactsDir(obj interface{}, filename string) error {


### PR DESCRIPTION
- ginkgo
 - golangci-lint

Plus fixing golangci-lint deprecation warnings due to this update