### PR TITLE
Bump ginkgo CLI in containerfiles

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -14,7 +14,7 @@ RUN cd /usr/local/bin \
 
 # Install dependencies: `golangci-lint & ginkgo`
 RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
-RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.9.0
+RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.9.1
 
 RUN mkdir /test-run-results && chmod 777 /test-run-results
 

--- a/Containerfile.osde2e
+++ b/Containerfile.osde2e
@@ -16,7 +16,7 @@ ARG OCP_CLI_URL=https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp
 RUN curl -L ${OCP_CLI_URL} | tar xfz - -C /usr/local/bin oc
 
 # Install dependencies: `ginkgo`
-RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.9.0
+RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.9.1
 
 RUN mkdir /test-run-results && chmod 777 /test-run-results
 


### PR DESCRIPTION
ginkgo from 2.9.0 to 2.9.1

In response to #40 