### PR TITLE
improving `GetVarDefault` function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,12 @@ osde2e_test: test_ocp_connection
 gpu_addon_must_gather:
 	@./hack/run_test.sh gpu_addon_must_gather
 
+.PHONY: unittest
+unittest:
+	@for folder in "internal" "ocputils"; do \
+		go test ./$$folder -count=1; \
+	done
+
 .PHONY: lint
 lint:
 	golangci-lint run -v

--- a/internal/config.go
+++ b/internal/config.go
@@ -29,11 +29,10 @@ var Config = config{
 }
 
 func GetVarDefault(evar string, _default string) string {
-	val := os.Getenv(evar)
-	if len(val) == 0 {
-		return _default
+	if val, ok := os.LookupEnv(evar); ok && len(val) > 0 {
+		return val
 	}
-	return val
+	return _default
 }
 
 func GetClientConfig() *rest.Config {

--- a/internal/config_test.go
+++ b/internal/config_test.go
@@ -1,0 +1,82 @@
+package internal
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func Check(err error, msg string) bool {
+	if err == nil {
+		return true
+	}
+	panic(msg)
+}
+
+func CreateFakeKubeConfig() {
+	data := []byte(`
+	apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: /fake/.minikube/ca.crt
+    server: https://10.10.10.10:8443
+  name: minikube
+contexts:
+- context:
+    cluster: minikube
+    user: minikube
+  name: minikube
+current-context: minikube
+kind: Config
+preferences: {}
+users:
+- name: minikube
+  user:
+    client-certificate-data: /workdir/.minikube/client.crt
+    client-key-data: /workdir/.minikube/client.key
+`)
+
+	file, err := os.Create(".kubeconfig")
+	Check(err, "Cannot create file .kubeconfig")
+
+	defer file.Close()
+	_, err = file.Write(data)
+	Check(err, "Cannot Write file .kubeconfig")
+	file.Sync()
+
+}
+
+func TestGetVarDefault(t *testing.T) {
+	// Test case when environment variable is set
+	name, val := "TestGetVarDefault", "value"
+	os.Setenv(name, val)
+	actual := GetVarDefault(name, "default")
+	if actual != val {
+		t.Errorf("GetVarDefault returned wrong value for set environment variable, expected: %s, got: %s", val, actual)
+	}
+
+	//Test case when environment variable is not set
+	val = "default"
+	actual = GetVarDefault("UNDEFINED", val)
+	if actual != val {
+		t.Errorf("GetVarDefault returned wrong value for unset environment variable, expected: %s, got: %s", val, actual)
+	}
+	// Test case when environment variable is empty string
+	name, val, expected := "TestGetVarDefault", "", "default"
+	os.Setenv(name, val)
+	actual = GetVarDefault(name, expected)
+	if actual != expected {
+		t.Errorf("GetVarDefault returned wrong value for empty string, expected: %s, got: %s", expected, actual)
+	}
+}
+
+func TestGetClientConfig(t *testing.T) {
+	// create fake kubeconfig file
+	CreateFakeKubeConfig()
+
+	config, expected := GetClientConfig(), "*rest.Config"
+	if (fmt.Sprintf("%T", config)) != "*rest.Config" {
+		t.Errorf("GetClientConfig returned wrong config, expected: %v, got: %T", expected, config)
+	}
+	os.Remove(".kubeconfig")
+}

--- a/internal/config_test.go
+++ b/internal/config_test.go
@@ -74,10 +74,10 @@ func TestGetVarDefault(t *testing.T) {
 func TestGetClientConfig(t *testing.T) {
 	// create fake kubeconfig file
 	CreateFakeKubeConfig()
-
+	defer os.Remove(".kubeconfig")
 	config, expected := GetClientConfig(), "*rest.Config"
 	if (fmt.Sprintf("%T", config)) != "*rest.Config" {
 		t.Errorf("GetClientConfig returned wrong config, expected: %v, got: %T", expected, config)
 	}
-	os.Remove(".kubeconfig")
+	
 }

--- a/internal/config_test.go
+++ b/internal/config_test.go
@@ -42,7 +42,8 @@ users:
 	defer file.Close()
 	_, err = file.Write(data)
 	Check(err, "Cannot Write file .kubeconfig")
-	file.Sync()
+	err = file.Sync()
+	Check(err, "Failed to flush file data")
 
 }
 


### PR DESCRIPTION
Making function smaller and more readable 
for best practice we should use `if True` statement instead of `if False` - optimize performance

here  is an example of output of running old vs. new function 
```bash
$ go run main.go 
CURRENT METHOD 1
yes
time run: 19.285µs
NEW METHOD 2
yes
time run: 1.263µs
```
almost 20 times   faster