### PR TITLE
Added a target to deploy and test a custom GPU operator bundles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,13 @@ e2e_gpu_test: deploy_gpu_operator gpu_full_test
 .PHONY: master_e2e_gpu_test
 master_e2e_gpu_test: deploy_gpu_operator_master gpu_full_test
 
+.PHONY: bundle_e2e_gpu_test
+bundle_e2e_gpu_test: deploy_gpu_from_bundle gpu_full_test
+
+.PHONY: deploy_gpu_from_bundle
+deploy_gpu_from_bundle: deploy_nfd_operator
+	@./hack/run_test.sh deploy_gpu_from_bundle $(GPU_BUNDLE)
+
 .PHONY: deploy_gpu_operator_master
 deploy_gpu_operator_master: deploy_nfd_operator
 	@./hack/run_test.sh deploy_gpu_operator_master

--- a/README.md
+++ b/README.md
@@ -14,4 +14,7 @@ $ make deploy_gpu_operator CHANNEL=v1.10
 $ make e2e_gpu_test
 # scale gpu machine set
 $ make scale_aws_gpu_nodes [REPLICAS=1 INSTANCE_TYPE=g4dn.xlarge]
+# run e2e test on a gpu operator bundle
+$ make bundle_e2e_gpu_test BUNDLE=my_bundle.to/test:latest
+
 ```

--- a/setup/deploy_gpu_op_test.go
+++ b/setup/deploy_gpu_op_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	deployedFromMaster = "DEPLOYED_FROM_MASTER"
+	deployedFromBundle = "DEPLOYED_FROM_BUNDLE"
 )
 
 var _ = Describe("deploy_gpu_operator :", Ordered, func() {
@@ -53,7 +53,7 @@ var _ = Describe("deploy_gpu_operator :", Ordered, func() {
 
 	Context("from certified operators", Ordered, func() {
 		BeforeAll(func() {
-			if testutils.SkipTestIfEnvVarSet(deployedFromMaster, true) {
+			if testutils.SkipTestIfEnvVarSet(deployedFromBundle, true) {
 				return
 			}
 		})


### PR DESCRIPTION
This PR adds the ability to deploy/test prebuilt gpu-operator bundles. 

by running 
```
# Simple deploy, including NFD and ClusterPolicy. (No tests)
make deploy_gpu_from_bundle GPU_BUNDLE=my.bundle/to:deploy

# Run an e2e test. Deploy bundle and test against it
make bundle_e2e_gpu_test GPU_BUNDLE=my.bundle/to:test
```