### PR TITLE
Workload tweaks: Daemonset and test waits

### DIFF
--- a/tests/gpu_burn_daemonset.go
+++ b/tests/gpu_burn_daemonset.go
@@ -8,7 +8,8 @@ import (
 )
 
 var (
-	no bool = false
+	no  bool = false
+	yes bool = true
 )
 
 func newBurnDaemonSet(namespace string, name string, gpuBurnImage string) *appsv1.DaemonSet {
@@ -37,6 +38,12 @@ func newBurnDaemonSet(namespace string, name string, gpuBurnImage string) *appsv
 					},
 				},
 				Spec: corev1.PodSpec{
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot: &yes,
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
 					Tolerations: []corev1.Toleration{
 						{
 							Operator: corev1.TolerationOpExists,
@@ -53,6 +60,11 @@ func newBurnDaemonSet(namespace string, name string, gpuBurnImage string) *appsv
 							ImagePullPolicy: corev1.PullAlways,
 							SecurityContext: &corev1.SecurityContext{
 								AllowPrivilegeEscalation: &no,
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{
+										"ALL",
+									},
+								},
 							},
 							Name: "gpu-burn-ctr",
 							Command: []string{

--- a/tests/run_gpu_workload_test.go
+++ b/tests/run_gpu_workload_test.go
@@ -82,9 +82,9 @@ var _ = Describe("run_gpu_workload :", Ordered, func() {
 			if err != nil {
 				return false
 			}
-			return ds.Status.NumberReady == ds.Status.DesiredNumberScheduled
+			return ds.Status.DesiredNumberScheduled != 0 && ds.Status.NumberReady == ds.Status.DesiredNumberScheduled
 		}, 20, 30*time.Second)
-		Expect(err).ToNot(HaveOccurred(), "Desired != Ready")
+		Expect(err).ToNot(HaveOccurred(), "Desired != Ready or desired is 0.")
 		err = testutils.SaveAsJsonToArtifactsDir(ds, "gpu_burn_daemonset.json")
 		Expect(err).ToNot(HaveOccurred())
 	})


### PR DESCRIPTION
- Adding pod security context to remove warnings.
 - Await for daemon set to report at least on pod desired.