### PR TITLE
Update to the "master-bundle" from NVIDIA

### DIFF
--- a/hack/run_test.sh
+++ b/hack/run_test.sh
@@ -4,7 +4,7 @@ THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 export ARTIFACT_DIR=${ARTIFACT_DIR:="/tmp/gpu-test"}
 export KUBECONFIG=${KUBECONFIG:="$HOME/.kube/config"}
-export GPU_OPERATOR_MASTER_BUNDLE="registry.gitlab.com/nvidia/kubernetes/gpu-operator/staging/gpu-operator-bundle:master-latest"
+export GPU_OPERATOR_MASTER_BUNDLE="registry.gitlab.com/nvidia/kubernetes/gpu-operator/staging/gpu-operator-bundle:release-23.03-latest"
 
 #####################
 ## Setup functions ##


### PR DESCRIPTION
According to NVIDIA, we should test the latest release ubi bundles.

Updated the image to:
registry.gitlab.com/nvidia/kubernetes/gpu-operator/staging/gpu-operator:release-23.03-latest-ubi8

Once they have a new release branch and bundle image, we would need to update again.