### PR TITLE
Remove SeccompProfile to make burn DaemonSet use the default

### DIFF
--- a/tests/gpu_burn_daemonset.go
+++ b/tests/gpu_burn_daemonset.go
@@ -40,9 +40,6 @@ func newBurnDaemonSet(namespace string, name string, gpuBurnImage string) *appsv
 				Spec: corev1.PodSpec{
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsNonRoot: &yes,
-						SeccompProfile: &corev1.SeccompProfile{
-							Type: corev1.SeccompProfileTypeRuntimeDefault,
-						},
 					},
 					Tolerations: []corev1.Toleration{
 						{


### PR DESCRIPTION
Remove the `seccompProfile` definition from the GPU burn DaemonSet resource and make it use the default (restricted) according to the OCP version it runs on.