### PR TITLE
Bump ginkgo from 2.9.5 to 2.9.7

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -14,7 +14,7 @@ RUN cd /usr/local/bin \
 
 # Install dependencies: `golangci-lint & ginkgo`
 RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
-RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.9.5
+RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.9.7
 
 RUN mkdir /test-run-results && chmod 777 /test-run-results
 

--- a/Containerfile.osde2e
+++ b/Containerfile.osde2e
@@ -16,7 +16,7 @@ ARG OCP_CLI_URL=https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp
 RUN curl -L ${OCP_CLI_URL} | tar xfz - -C /usr/local/bin oc
 
 # Install dependencies: `ginkgo`
-RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.9.5
+RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.9.7
 
 RUN mkdir /test-run-results && chmod 777 /test-run-results
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/NVIDIA/gpu-operator v1.11.1
 	github.com/blang/semver/v4 v4.0.0
-	github.com/onsi/ginkgo/v2 v2.9.5
+	github.com/onsi/ginkgo/v2 v2.9.7
 	github.com/onsi/gomega v1.27.7
 	github.com/openshift/api v0.0.0-20221116152553-4b67c2b2bb1e
 	github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c

--- a/go.sum
+++ b/go.sum
@@ -567,8 +567,8 @@ github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.14.1/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
-github.com/onsi/ginkgo/v2 v2.9.5 h1:+6Hr4uxzP4XIUyAkg61dWBw8lb/gc4/X5luuxN/EC+Q=
-github.com/onsi/ginkgo/v2 v2.9.5/go.mod h1:tvAoo1QUJwNEU2ITftXTpR7R1RbCzoZUOs3RonqW57k=
+github.com/onsi/ginkgo/v2 v2.9.7 h1:06xGQy5www2oN160RtEZoTvnP2sPhEfePYmCDc2szss=
+github.com/onsi/ginkgo/v2 v2.9.7/go.mod h1:cxrmXWykAwTwhQsJOPfdIDiJ+l2RYq7U8hFU+M/1uw0=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=

--- a/vendor/github.com/onsi/ginkgo/v2/CHANGELOG.md
+++ b/vendor/github.com/onsi/ginkgo/v2/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 2.9.7
+
+### Fixes
+- fix race when multiple defercleanups are called in goroutines [07fc3a0]
+
+## 2.9.6
+
+### Fixes
+- fix: create parent directory before report files (#1212) [0ac65de]
+
+### Maintenance
+- Bump github.com/onsi/gomega from 1.27.6 to 1.27.7 (#1202) [3e39231]
+
 ## 2.9.5
 
 ### Fixes

--- a/vendor/github.com/onsi/ginkgo/v2/internal/suite.go
+++ b/vendor/github.com/onsi/ginkgo/v2/internal/suite.go
@@ -245,7 +245,9 @@ func (suite *Suite) pushCleanupNode(node Node) error {
 
 	node.NodeIDWhereCleanupWasGenerated = suite.currentNode.ID
 	node.NestingLevel = suite.currentNode.NestingLevel
+	suite.selectiveLock.Lock()
 	suite.cleanupNodes = append(suite.cleanupNodes, node)
+	suite.selectiveLock.Unlock()
 
 	return nil
 }

--- a/vendor/github.com/onsi/ginkgo/v2/reporters/json_report.go
+++ b/vendor/github.com/onsi/ginkgo/v2/reporters/json_report.go
@@ -4,12 +4,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path"
 
 	"github.com/onsi/ginkgo/v2/types"
 )
 
-//GenerateJSONReport produces a JSON-formatted report at the passed in destination
+// GenerateJSONReport produces a JSON-formatted report at the passed in destination
 func GenerateJSONReport(report types.Report, destination string) error {
+	if err := os.MkdirAll(path.Dir(destination), 0770); err != nil {
+		return err
+	}
 	f, err := os.Create(destination)
 	if err != nil {
 		return err
@@ -25,8 +29,8 @@ func GenerateJSONReport(report types.Report, destination string) error {
 	return f.Close()
 }
 
-//MergeJSONReports produces a single JSON-formatted report at the passed in destination by merging the JSON-formatted reports provided in sources
-//It skips over reports that fail to decode but reports on them via the returned messages []string
+// MergeJSONReports produces a single JSON-formatted report at the passed in destination by merging the JSON-formatted reports provided in sources
+// It skips over reports that fail to decode but reports on them via the returned messages []string
 func MergeAndCleanupJSONReports(sources []string, destination string) ([]string, error) {
 	messages := []string{}
 	allReports := []types.Report{}
@@ -46,6 +50,9 @@ func MergeAndCleanupJSONReports(sources []string, destination string) ([]string,
 		allReports = append(allReports, reports...)
 	}
 
+	if err := os.MkdirAll(path.Dir(destination), 0770); err != nil {
+		return messages, err
+	}
 	f, err := os.Create(destination)
 	if err != nil {
 		return messages, err

--- a/vendor/github.com/onsi/ginkgo/v2/reporters/junit_report.go
+++ b/vendor/github.com/onsi/ginkgo/v2/reporters/junit_report.go
@@ -14,6 +14,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"os"
+	"path"
 	"strings"
 
 	"github.com/onsi/ginkgo/v2/config"
@@ -285,6 +286,9 @@ func GenerateJUnitReportWithConfig(report types.Report, dst string, config Junit
 		TestSuites: []JUnitTestSuite{suite},
 	}
 
+	if err := os.MkdirAll(path.Dir(dst), 0770); err != nil {
+		return err
+	}
 	f, err := os.Create(dst)
 	if err != nil {
 		return err
@@ -322,6 +326,9 @@ func MergeAndCleanupJUnitReports(sources []string, dst string) ([]string, error)
 		mergedReport.TestSuites = append(mergedReport.TestSuites, report.TestSuites...)
 	}
 
+	if err := os.MkdirAll(path.Dir(dst), 0770); err != nil {
+		return messages, err
+	}
 	f, err := os.Create(dst)
 	if err != nil {
 		return messages, err

--- a/vendor/github.com/onsi/ginkgo/v2/reporters/teamcity_report.go
+++ b/vendor/github.com/onsi/ginkgo/v2/reporters/teamcity_report.go
@@ -11,6 +11,7 @@ package reporters
 import (
 	"fmt"
 	"os"
+	"path"
 	"strings"
 
 	"github.com/onsi/ginkgo/v2/types"
@@ -27,6 +28,9 @@ func tcEscape(s string) string {
 }
 
 func GenerateTeamcityReport(report types.Report, dst string) error {
+	if err := os.MkdirAll(path.Dir(dst), 0770); err != nil {
+		return err
+	}
 	f, err := os.Create(dst)
 	if err != nil {
 		return err

--- a/vendor/github.com/onsi/ginkgo/v2/types/version.go
+++ b/vendor/github.com/onsi/ginkgo/v2/types/version.go
@@ -1,3 +1,3 @@
 package types
 
-const VERSION = "2.9.5"
+const VERSION = "2.9.7"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -105,7 +105,7 @@ github.com/modern-go/reflect2
 # github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 ## explicit
 github.com/munnerz/goautoneg
-# github.com/onsi/ginkgo/v2 v2.9.5
+# github.com/onsi/ginkgo/v2 v2.9.7
 ## explicit; go 1.18
 github.com/onsi/ginkgo/v2
 github.com/onsi/ginkgo/v2/config


### PR DESCRIPTION
Bumps github.com/onsi/ginkgo/v2 from 2.9.5 to 2.9.7.