### PR TITLE
Define dependabot groupings for k8s and ginkgo/gomega

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,15 @@ updates:
     directory: /
     schedule:
       interval: daily
+    groups:
+      k8s:
+        patterns:
+          - "k8s.io/*"
+      gomega:
+        patterns:
+          - "github.com/onsi/ginkgo"
+          - "github.com/onsi/gomega"
+
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
Make dependabot update in a single PR dependencies that are usually released together