### PR TITLE
Fix seccomprofile warning, add tests

### DIFF
--- a/tests/gpu_burn_daemonset.go
+++ b/tests/gpu_burn_daemonset.go
@@ -56,6 +56,10 @@ func newBurnDaemonSet(namespace string, name string, gpuBurnImage string) *appsv
 							Image:           gpuBurnImage,
 							ImagePullPolicy: corev1.PullAlways,
 							SecurityContext: &corev1.SecurityContext{
+								RunAsNonRoot: &yes,
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
 								AllowPrivilegeEscalation: &no,
 								Capabilities: &corev1.Capabilities{
 									Drop: []corev1.Capability{


### PR DESCRIPTION
1. More complete security profile definition for GPU burn
2. Add SeccompProfile warning now that all OCP versions support it (see PR #62)
3. Add more intermediate test to verify all steps of GPU readiness
   * NVIDIA-added GPU label
   * Discovered GPU capacity